### PR TITLE
Fix: Proper Sender missile fire

### DIFF
--- a/content/units/mech/16p-03-sender.hjson
+++ b/content/units/mech/16p-03-sender.hjson
@@ -67,6 +67,16 @@ weapons: [
         lightningDamage: 2
       }
     }
+	shoot: {
+	  barrels: [
+	  -6, -2.25f, 0,
+	  -2, -1.25f, 0 
+	  2, -1.25f, 0, 
+	  6, -2.25f, 0]
+	  type: ShootBarrel
+	  shots: 5
+	  shotDelay: 3f
+	  }
   }
     {
     x: 12

--- a/content/units/mech/16p-03-sender.hjson
+++ b/content/units/mech/16p-03-sender.hjson
@@ -74,7 +74,7 @@ weapons: [
 	  2, -1.25f, 0, 
 	  6, -2.25f, 0]
 	  type: ShootBarrel
-	  shots: 5
+	  shots: 4
 	  shotDelay: 3f
 	  }
   }


### PR DESCRIPTION
In order to match whre the missile fires, Sender's missile launcher must be fixed.
Note:
- some value aren't perfect/proper/unbalance, adjust it yourself


https://github.com/user-attachments/assets/a48645d7-867a-4929-80f4-981725ecc9a7

